### PR TITLE
fix package version, no PR builds

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -6,10 +6,13 @@ pool:
   vmImage: macOS-latest
   demands: npm
 
+# no PR builds
+pr: none
+
 name: 1.0.$(BuildID)
 steps:
   - powershell: |
-      $branchName = "$Env:Build_SourceBranchName"
+      $branchName = "$(Build.SourceBranchName)"
 
       # Empty name when branch is master
       if ($branchName -eq "master"){


### PR DESCRIPTION
I missed this on the previous update to the `azure-pipelines.yml` and the resulting NPM package was being published with two trailing hyphens `--`.

I assume that no PR builds is also desirable following the approach of other repos.